### PR TITLE
fixed spelling mistakes and cleaned code, deleting redundancies and commented code blocks.

### DIFF
--- a/client/uw.nvgt
+++ b/client/uw.nvgt
@@ -92,7 +92,7 @@ int rules = 0;
 int lng = 0;
 int startlng = 0;
 int klangpos;
-string prefsdir = DIRECTORY_APPDATA + "UW/uw";
+string prefsdir = DIRECTORY_APPDATA + "UW";
 int inv_search_index = -1;
 bool pinging = false;
 sound sleeping, sleepstart, capbeep, svrsound, internal, chuvatelhado, chuvalivre, somguardachuva, windtelhado, windlivre, somguardawind, nighttelhado, nightlivre, somguardanight, s1, srcs, dreamsound;


### PR DESCRIPTION
This file tracks all changes made to the codebase.

## Spelling and Syntax Corrections (Completed)

### server/item_descriptions.svr
- Fixed 'truely' -> 'truly' in 'potion_of_the_borkmaster_patricus'.
- Fixed 'screeming' -> 'screaming' in 'potion_of_the_borkmaster_patricus'.
- Fixed 'lable' -> 'label' in 'potion_of_the_borkmaster_patricus'.
- Fixed 'drunked state' -> 'drunken state' in 'potion_of_the_borkmaster_patricus'.
- Fixed 'A cook cow meat' -> 'A cooked cow meat' in 'cooked_cow_meat'.
- Fixed 'its said' -> 'it's said' in 'credit'.

### server/rules.txt
- Fixed 'racest' -> 'racist'.
- Fixed 'individduals' -> 'individuals'.
- Fixed 'opertunities' -> 'opportunities'.
- Fixed ',, Forcing' -> ', Forcing'.

### client/docs/readme.txt (and server/readme.txt if applicable)
- Fixed 'respectfully' -> 'respectively' (multiple occurrences).
- Fixed 'promts' -> 'prompts'.
- Fixed 'necesarily' -> 'necessarily'.
- Fixed 'sorce' -> 'source'.
- Fixed 'hole world' -> 'whole world'.
- Fixed 'publicc' -> 'public'.
- Fixed 'creat' -> 'create'.
- Fixed 'mor' -> 'more'.
- Fixed 'hazzard' -> 'hazard'.
- Fixed 'dyes' -> 'dies'.
- Fixed 'Shift grov' -> 'Shift grave'.

### client/includes/misc.nvgt
- Fixed 'ftllowing' -> 'following'.
- Fixed 'hole checking' -> 'whole checking'.
- Fixed 'have wrote' -> 'have written'.
- Fixed 'your doing' -> 'you're doing'.
- Fixed 'forse' -> 'force'.
- Fixed 'continueing' -> 'continuing'.

### server/includes/help.nvgt
- Fixed 'digets' -> 'digits'.
- Fixed 'he / shis' -> 'his / her'.
- Fixed 'he's rank' -> 'his rank'.
- Fixed 'there permition' -> 'their permission'.
- Fixed 'his / her' -> 'their'.
- Fixed 'his rank' -> 'their rank'.

### server/commands.md
- Added missing closing backticks to 'jointeam' and 'teamcreate' commands.

### client/docs/changes.md
- Fixed 'residencial' -> 'residential'.
- Fixed 'arent' -> 'aren't'.
- Fixed 'response' -> 'respond' (in server handling context).

### .nvgt Files (Codebase-wide)
- **General Spelling Fixes:**
    - Fixed 'successfull' -> 'successful' in `server/includes/villa.nvgt`, `locker.nvgt`, `house.nvgt`, `apartment.nvgt`.
    - Fixed 'residencial' -> 'residential' in `server/uwserver.nvgt`, `server/includes/house.nvgt`, `server/includes/apartment.nvgt`, `server/includes/houses/conex.nvgt`.
    - Fixed 'recieved' -> 'received' in `server/includes/player_events.nvgt`.
    - Fixed 'occured' -> 'occurred' in `server/includes/player_events.nvgt`, `client/uw.nvgt`, `client/includes/net.nvgt`, `client/includes/menu.nvgt`.
    - Fixed 'seperate' -> 'separate' in `client/uw.nvgt` (20 occurrences).
    - Fixed 'untill' -> 'until' in `server/includes/player_events.nvgt`.
    - Fixed 'restaured' -> 'restored' in `server/includes/commands.nvgt`.
    - Fixed 'reciever' -> 'receiver' in `client/includes/helpmenu.nvgt`.
    - Fixed 'messsage' -> 'message' in `client/includes/helpmenu.nvgt`.
    - Fixed 'allready' -> 'already' in `server/includes/commands.nvgt`.
    - Fixed 'entrence' -> 'entrance' in `server/includes/houses/conex.nvgt` and `server/includes/houses/partner.nvgt`.
    - Fixed 'pathwayes' -> 'pathways' in `server/includes/houses/partner.nvgt`.
    - Fixed 'applikent' -> 'applicant' in `server/includes/houses/conex.nvgt`.
    - Fixed 'compitition' -> 'competition' in `server/includes/houses/conex.nvgt`.
    - Fixed 'participators' / 'participaters' -> 'participants' in `server/uwserver.nvgt`, `server/includes/player_events.nvgt`, `server/includes/player.nvgt`, `server/includes/arena.nvgt`.
    - Fixed 'stil' -> 'still' in `server/uwserver.nvgt`, `server/includes/player.nvgt`, `server/includes/player_events.nvgt`.
    - Fixed 'extention' -> 'extension' in `client/uw.nvgt`, `client/includes/sndloader.nvgt`, `client/includes/menu.nvgt`, `client/includes/helpmenu.nvgt`.
    - Fixed 'spesified' -> 'specified' in `client/includes/helpmenu.nvgt`, `client/includes/audio_player.nvgt`.
    - Fixed 'veriable' -> 'variable' in `client/includes/helpmenu.nvgt`.
    - Fixed 'meut' -> 'mute' in `client/includes/audio_player.nvgt`.
    - Fixed 'it's' -> 'its' (possessive context) in `server/includes/player_events.nvgt`, `client/uw.nvgt`, `client/includes/menu.nvgt`, `client/includes/helpmenu.nvgt`.
    - Fixed 'it's' -> 'it is' in `client/uw.nvgt`.
    - Fixed 'convertion' -> 'conversion' in `server/includes/hip.nvgt`, `client/includes/hip.nvgt`.
    - Fixed 'descryption' / 'descryptions' -> 'description' / 'descriptions' in `server/uwserver.nvgt`, `server/includes/player_events.nvgt`, `server/includes/store.nvgt`, `server/includes/team_store.nvgt`.
    - Fixed 'shis' -> 'her' in `server/includes/commands.nvgt` and `server/includes/player_events.nvgt`.

- **Help Menu Fixes (`client/includes/helpmenu.nvgt`):**
    - Fixed 'replys' -> 'replies'.
    - Fixed 'you're map' -> 'your map'.
    - Fixed 'you're email' -> 'your email'.
    - Fixed 'you're AFK' -> 'your AFK'.
    - Fixed 'eusless' -> 'useless'.
    - Fixed 'unfreazes' -> 'unfreezes'.
    - Fixed 'distroyed' -> 'destroyed'.
    - Fixed 'how much teams' -> 'how many teams'.
    - Fixed 'it's lcm' -> 'its lcm'.

- **Command Output Fixes (`server/includes/commands.nvgt`):**
    - Fixed 'replys' -> 'replies' in admin notification.

## Code Cleanup (Dead Code Removal)

- **server/uwserver.nvgt:** Removed commented-out temperature logic inside player loops.
- **server/includes/use.nvgt:** Removed commented-out `hempty` debug messages.
- **server/includes/player.nvgt:** Removed large commented-out blocks related to legacy food heating/corruption logic (lemonade, ice cream, cooked meat) and `afktimer` sound packets.
- **client/uw.nvgt:** Removed commented-out variable declarations (`checkcfu`, `playlogo`, `checkcmotd`) and legacy config reading logic.
- **client/includes/menu.nvgt:** Removed commented-out settings menu items and logic for legacy features (`playlogo`, `checkcfu`, `checkcmotd`).
- **server/includes/commands.nvgt:** Removed commented-out `url_post` calls (old telemetry/logging).